### PR TITLE
Fixed potential typo of font family (YuMincho)

### DIFF
--- a/R/graphics_settings.R
+++ b/R/graphics_settings.R
@@ -34,7 +34,7 @@ get_default_font_family <- function(engine = "xelatex"){
   } else if(fam == "hiragino-pron") {
     font <- c(serif = "Hiragino Mincho ProN", sans = "Hiragino Sans")
   } else if(fam == "yu-osx") {
-    font <- c(serif = "YuMicho", sans = "YuGothic")
+    font <- c(serif = "YuMincho", sans = "YuGothic")
   } else if(grepl("^yu-win", fam)) {
     font <- c(serif = "Yu Mincho", sans = "Yu Gothic")
   } else if(fam == "ms"){


### PR DESCRIPTION
The Font Family name "YuMincho" for OSX was written in "YuMicho", and it caused an error when running the minimal example (ggplot). 

The error was: 
Error in grid.Call(C_textBounds, as.graphicsAnnot(x$label), x$x, x$y, : polygon edge not found.

After fixing the typo, the minimal example ran without any issues.